### PR TITLE
Update scheduled actions to use slice reference for proper marshalling

### DIFF
--- a/service.go
+++ b/service.go
@@ -79,7 +79,7 @@ type Service struct {
 	Teams                  []Team               `json:"teams,omitempty"`
 	IncidentUrgencyRule    *IncidentUrgencyRule `json:"incident_urgency_rule,omitempty"`
 	SupportHours           *SupportHours        `json:"support_hours,omitempty"`
-	ScheduledActions       []ScheduledAction    `json:"scheduled_actions,omitempty"`
+	ScheduledActions       *[]ScheduledAction    `json:"scheduled_actions,omitempty"`
 	AlertCreation          string               `json:"alert_creation,omitempty"`
 	AlertGrouping          string               `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout   *uint                `json:"alert_grouping_timeout,omitempty"`


### PR DESCRIPTION
For slices, `omitempty` will omit the field if the slice has no elements, even if `make` is used. Use a reference here to allow proper JSON marshaling. Without this change, it is _impossible_ to pass in an empty `ScheduledActions` through to the `UpdateService` `put` payload. (An empty `ScheduledActions` indicates that we do NOT want to update incident urgency during a `SupportHours` transition. We need to support this use case.)